### PR TITLE
Have a logfile path of '-' use stderr as log output.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -689,13 +689,13 @@ impl ConfigPath {
 
 impl From<PathBuf> for ConfigPath {
     fn from(path: PathBuf) -> Self {
-        Self(path)
+        Self::construct(path)
     }
 }
 
 impl From<String> for ConfigPath {
     fn from(path: String) -> Self {
-        Self(path.into())
+        Self::construct(path.into())
     }
 }
 


### PR DESCRIPTION
This PR changes the logging configuration to treat a `-` as the log file path as an indication to log to stderr instead.

While this is redundant with explicitly logging to stderr, this is also what people at least on Unix-y systems would expect to happen.