### PR TITLE
Fix missing setgroups() call.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daemonbase"
-version = "0.1.3"
+version = "0.1.4-dev"
 edition = "2021"
 rust-version = "1.81"
 authors = ["NLnet Labs <rust-team@nlnetlabs.nl>"]


### PR DESCRIPTION
See: https://github.com/rpm-software-management/rpmlint/blob/fb00ae4bea5905491a8b1ca0e14e38f97cebe8ea/rpmlint/descriptions/BinariesCheck.toml#L120