### PR TITLE
Fix `mismatched_lifetime_syntaxes` warning.

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -559,7 +559,7 @@ impl Dispatch {
     }
 
     /// Returns a mutex lock for the target
-    fn target(&self) -> MutexGuard<LogBackend> {
+    fn target(&self) -> MutexGuard<'_, LogBackend> {
         self.target.lock().expect("poisoned mutex")
     }
 


### PR DESCRIPTION
This PR fixes the `mismatched_lifetime_syntaxes` warning introduced in Rust 1.89 (?).