### PR TITLE
Rework setting of user and group ID.

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -517,8 +517,8 @@ mod unix {
         /// The user name as a C string.
         ///
         /// This is used internally. We keep both the string and C string
-        /// versions because conversion can cause errors and we want to catch
-        /// those early.
+        /// versions because conversion can cause errors, so it best happens
+        /// already when creating an object.
         c_name: CString,
 
         /// The numerical user ID.

--- a/src/process.rs
+++ b/src/process.rs
@@ -185,6 +185,7 @@ mod unix {
                 }
 
                 {
+                    #[allow(unused_imports)]
                     use nix::libc::*;
 
                     if unsafe { setregid(rgid.as_raw(), egid.as_raw()) } != 0 {
@@ -208,6 +209,7 @@ mod unix {
                 }
 
                 {
+                    #[allow(unused_imports)]
                     use nix::libc::*;
 
                     if unsafe { setreuid(ruid.as_raw(), euid.as_raw()) } != 0 {
@@ -231,6 +233,7 @@ mod unix {
 
             // Let the system load the supplemental groups for the user.
             {
+                #[allow(unused_imports)]
                 use nix::unistd::*;
 
                 initgroups(&user.c_name, gid).map_err(|err| {
@@ -244,6 +247,7 @@ mod unix {
 
             // Set the group ID.
             {
+                #[allow(unused_imports)]
                 use nix::unistd::*;
 
                 setresgid(gid, gid, gid).map_err(|err| {
@@ -256,6 +260,7 @@ mod unix {
 
             // Set the user ID.
             {
+                #[allow(unused_imports)]
                 use nix::unistd::*;
 
                 setresuid(user.uid, user.uid, user.uid).map_err(|err| {

--- a/src/process.rs
+++ b/src/process.rs
@@ -159,7 +159,7 @@ mod unix {
             // crate, we define fallback functions and overwrite their symbol
             // if possible using a glob import.
             //
-            // For setting uid and gid, we need to cascase: Use `setresuid`
+            // For setting uid and gid, we need to cascade: Use `setresuid`
             // if available, otherwise use `setreuid` if available, otherwise
             // use `setuid`; analogous for gid. We achieve this by having
             // the fallback call the next step which may itself be a fallback.
@@ -238,8 +238,7 @@ mod unix {
 
                 initgroups(&user.c_name, gid).map_err(|err| {
                     error!(
-                        "failed to initgroups {}: {}",
-                        user.name, err
+                        "failed to initialize the group access list: {err}",
                     );
                     Failed
                 })?;


### PR DESCRIPTION
This PR updates setting of user and group ID along the lines of what Unbound does.

This requires a bit of trickery to be portable. I hope the commentary in the code is sufficient to explain what’s going on.

This PR builds on #9 and supersedes it.