### PR TITLE
Add `process::exit_signalled` waiting for both SIGINT and SIGTERM on Unix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono          = "0.4.23"
 clap            = { version = "4", features = [ "derive" ] }
 log             = "0.4.8"
 serde           = { version = "1.0.95", features = [ "derive" ] }
+tokio           = { version = "1.40", features = [ "macros", "signal" ], optional = true }
 toml_edit       = "0.23"
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,12 @@ Breaking changes
 
 New
 
+* Added a function `process::exit_signalled` that waits for commonly used
+  exit signals, in particular SIGINT and SIGTERM on Unix. This is only
+  available with the `tokio` feature. ([#23])
+
 Improvements
+
 * Provide public access to the fields of the logger and process
   configuration so you can use the crate with your own configuration
   means. ([#17])
@@ -16,6 +21,7 @@ Bug fixes
 Other changes
 
 [17]: https://github.com/NLnetLabs/daemonbase/pull/17
+[23]: https://github.com/NLnetLabs/daemonbase/pull/23
 
 
 ## 0.1.4

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,11 +3,17 @@
 #[cfg(unix)]
 pub use self::unix::{Args, Config, Process, UserId, GroupId};
 
+#[cfg(all(unix, feature = "tokio"))]
+pub use self::unix::exit_signalled;
+
 #[cfg(target_os = "linux")]
 pub use self::linux::EnvSockets;
 
 #[cfg(not(unix))]
 pub use self::not_unix::{Args, Config, Process};
+
+#[cfg(all(not(unix), feature = "tokio"))]
+pub use self::not_unix::exit_signalled;
 
 #[cfg(not(target_os = "linux"))]
 pub use self::not_linux::EnvSockets;
@@ -649,6 +655,31 @@ mod unix {
             user.name
         }
     }
+
+    //------------ exit_signalled --------------------------------------------
+
+    /// Returns when an exit signal was received.
+    ///
+    /// Returns when either a SIGINT or SIGTERM was received.
+    ///
+    #[cfg(feature = "tokio")]
+    pub async fn exit_signalled() -> Result<(), std::io::Error> {
+        use log::info;
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut sigterm = signal(SignalKind::terminate())?;
+        let mut sigint = signal(SignalKind::interrupt())?;
+
+        tokio::select! {
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM. Shutting down.");
+            }
+            _ = sigint.recv() => {
+                info!("Received SIGINT. Shutting down.");
+            }
+        }
+        Ok(())
+    }
 }
 
 /// An error occurred while working with environment variable derived socket
@@ -1207,6 +1238,17 @@ mod not_unix {
         pub fn into_config(&self) -> Config {
             Config
         }
+    }
+
+    //------------ exit_signalled --------------------------------------------
+
+    /// Returns when an exit signal was received.
+    ///
+    /// This non-Unix implementation returns when the equivalent of a Ctrl+C is
+    /// received.
+    #[cfg(feature = "tokio")]
+    pub async fn exit_signalled() -> Result<(), std::io::Error> {
+        tokio::signal::ctrl_c().await
     }
 }
 


### PR DESCRIPTION
This PR adds a new function `process::exit_signalled` that waits for a signal requesting a process exit using Tokio’s signal methods. This is feature gated on a `tokio` feature.

This PR is essentially #18 but it was easier to manually re-do it than fixing the merge conflicts.